### PR TITLE
KPV-1592

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,18 @@
 /.slcache
 /.gradle
 
+#This files have appeared changed after configuring out the intellij ultimate version
+#Some of them might not be needed to add them to .gitignore
+.gitattributes
+build.gradle
+gradle/
+gradlew
+gradlew.bat
+kuorum.ipr
+production/
+settings.gradle
+
+
 # Config files
 /src/java/development_config.properties
 /src/java/test_config.properties
@@ -50,3 +62,9 @@ covertura.ser
 
 #Images testing kuorum
 /images
+
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build

--- a/grails-app/controllers/kuorum/admin/AdminController.groovy
+++ b/grails-app/controllers/kuorum/admin/AdminController.groovy
@@ -280,7 +280,7 @@ class AdminController {
     def editDomainRelevantCampaigns() {
         List<CampaignRSDTO> domainCampaigns = campaignService.findRelevantDomainCampaigns()
         // TODO: BAD TRICK -> Recover all campaigns without pagination
-        CampaignPageRSDTO adminCampaigns = campaignService.findAllCampaigns(WebConstants.FAKE_LANDING_ALIAS_USER, null, false, 0, 1000)
+        CampaignPageRSDTO adminCampaigns = campaignService.findAllCampaigns(WebConstants.FAKE_LANDING_ALIAS_USER, null, false, 0, 1000, true)
         Map domainCampaignsId = [first:null, second:null, third:null]
         DomainRSDTO domainRSDTO = CustomDomainResolver.domainRSDTO
         domainCampaignsId.first = domainCampaigns && domainCampaigns.size()>0 ? domainCampaigns.get(0).id:null

--- a/grails-app/services/payment/campaign/CampaignService.groovy
+++ b/grails-app/services/payment/campaign/CampaignService.groovy
@@ -62,9 +62,9 @@ class CampaignService {
         findAllCampaigns(user.id.toString(), user.id.toString(), attachDrafts,page, size)
     }
 
-    CampaignPageRSDTO findAllCampaigns(String userId, String viewerUid = null, Boolean attachDrafts = false, Integer page = 0, Integer size = 10) {
+    CampaignPageRSDTO findAllCampaigns(String userId, String viewerUid = null, Boolean attachDrafts = false, Integer page = 0, Integer size = 10, Boolean onlyPublications=true) {
         Map<String, String> params = [userId: userId]
-        Map<String, String> query = [page:page,size:size,attachDrafts:attachDrafts]
+        Map<String, String> query = [page:page,size:size,attachDrafts:attachDrafts, onlyPublications:onlyPublications]
         if (viewerUid){
             query.put("viewerUid",viewerUid)
         }

--- a/grails-app/services/payment/campaign/CampaignService.groovy
+++ b/grails-app/services/payment/campaign/CampaignService.groovy
@@ -62,9 +62,9 @@ class CampaignService {
         findAllCampaigns(user.id.toString(), user.id.toString(), attachDrafts,page, size)
     }
 
-    CampaignPageRSDTO findAllCampaigns(String userId, String viewerUid = null, Boolean attachDrafts = false, Integer page = 0, Integer size = 10) {
+    CampaignPageRSDTO findAllCampaigns(String userId, String viewerUid = null, Boolean attachDrafts = false, Integer page = 0, Integer size = 10, Boolean onlyPublications=false) {
         Map<String, String> params = [userId: userId]
-        Map<String, String> query = [page:page,size:size,attachDrafts:attachDrafts]
+        Map<String, String> query = [page:page,size:size,attachDrafts:attachDrafts, onlyPublications:onlyPublications]
         if (viewerUid){
             query.put("viewerUid",viewerUid)
         }


### PR DESCRIPTION
To fix the problems with relevance which is being changed in the section relevant campaigns we have added to the method findAllCampaigns a flag which was already implemented but not activated.

Therefor the method is now ready to receive the flag `onlyPublications` true or false. It means if there are another places where we need to recover all of them it is ready to serve all of those campaigns just adding a false to that flag.