### PR TITLE
dev/KPV-1715 :: Removed decoding from front environment

### DIFF
--- a/grails-app/controllers/kuorum/politician/CampaignController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignController.groovy
@@ -267,7 +267,7 @@ class CampaignController {
             command = new CampaignContentCommand()
             if (campaignRSDTO) {
                 command.title = campaignRSDTO.title
-                command.body = URLDecoder.decode(campaignRSDTO.body, "UTF-8")
+                command.body = campaignRSDTO.body
                 //Links are encoded Hopefully, user not use URL encoding in his texts
                 if (campaignRSDTO.videoUrl) {
                     command.videoPost = campaignRSDTO.videoUrl


### PR DESCRIPTION
Front part of the task. Special character were not allowed in body when editing a campaign because of the URL decoder.