### PR TITLE
Dev/kpv 1822

### DIFF
--- a/grails-app/conf/ApplicationResources.groovy
+++ b/grails-app/conf/ApplicationResources.groovy
@@ -332,4 +332,9 @@ modules = {
 //        resource url:'js/modernizr.js'
 //        resource url:'js/map.js'
 //    }
+
+    domainValidation {
+        dependsOn 'forms'
+        resource url:'js/domainValidation.js'
+    }
 }

--- a/grails-app/controllers/kuorum/admin/AdminController.groovy
+++ b/grails-app/controllers/kuorum/admin/AdminController.groovy
@@ -135,7 +135,7 @@ class AdminController {
             return
         }
         DomainRDTO domainRDTO = getPopulatedDomainRDTO()
-        if (SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")) {
+        if (SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN") || SpringSecurityUtils.ifAllGranted("ROLE_ADMIN")) {
             domainRDTO.validationCensus = command.validationCensus ?: false
             domainRDTO.validationCode = command.validationCode ?: false
             domainRDTO.validationPhone = command.validationPhone ?: false

--- a/grails-app/controllers/kuorum/politician/CampaignController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignController.groovy
@@ -192,7 +192,7 @@ class CampaignController {
         if (command.eventAttached && !rdto.event) {
             rdto.event = new EventRDTO()
         }
-        if (rdto instanceof SurveyRDTO && grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")) {
+        if (rdto instanceof SurveyRDTO && (grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN") || grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_ADMIN"))) {
             //Custom logic of survey. May be this logic shouldn't be here
             rdto.voteType = command.voteType == null ? SurveyVoteTypeDTO.MANIFEST : command.voteType;
             rdto.signVotes = command.signVotes == null ? false : command.signVotes;

--- a/grails-app/controllers/kuorum/survey/SurveyController.groovy
+++ b/grails-app/controllers/kuorum/survey/SurveyController.groovy
@@ -88,8 +88,8 @@ class SurveyController extends CampaignController {
         def model = modelSettings(command, surveyRSDTO)
         command.debatable = false
         if (surveyRSDTO) {
-            command.voteType = surveyRSDTO.getVoteType()
-            command.signVotes = surveyRSDTO.getSignVotes()
+            command.voteType = command.voteType?:surveyRSDTO.getVoteType()
+            command.signVotes = command.signVotes?:surveyRSDTO.getSignVotes()
         }
         model.options = [debatable: false, showCampaignDateLimits: true, showSurveyCustomFields: true]
         return model

--- a/grails-app/controllers/kuorum/survey/SurveyController.groovy
+++ b/grails-app/controllers/kuorum/survey/SurveyController.groovy
@@ -88,8 +88,8 @@ class SurveyController extends CampaignController {
         def model = modelSettings(command, surveyRSDTO)
         command.debatable = false
         if (surveyRSDTO) {
-            command.voteType = command.voteType?:surveyRSDTO.getVoteType()
-            command.signVotes = command.signVotes?:surveyRSDTO.getSignVotes()
+            command.voteType = surveyRSDTO.getVoteType()
+            command.signVotes = surveyRSDTO.getSignVotes()
         }
         model.options = [debatable: false, showCampaignDateLimits: true, showSurveyCustomFields: true]
         return model

--- a/grails-app/views/admin/_domainValidationForm.gsp
+++ b/grails-app/views/admin/_domainValidationForm.gsp
@@ -1,3 +1,4 @@
+<g:set var="disabledForAdmins" value="${grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_ADMIN") || grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_SUPER_ADMIN")}" />
 <r:require modules="forms"/>
 <div class="box-ppal-section">
     <h4 class="box-ppal-section-title"><g:message code="kuorum.web.admin.domain.contentPrivacy.label"/></h4>
@@ -9,27 +10,27 @@
     <h4 class="box-ppal-section-title"><g:message code="kuorum.web.admin.domain.validation.label"/></h4>
     <fieldset class="row">
         <div class="form-group col-md-6">
-            <formUtil:checkBox command="${command}" field="validationCensus" showLabel="true" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+            <formUtil:checkBox command="${command}" field="validationCensus" showLabel="true" disabled="${!disabledForAdmins}"/>
         </div>
     </fieldset>
     <fieldset class="row">
         <div class="form-group col-md-6">
-            <formUtil:checkBox command="${command}" field="validationCode" showLabel="true" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+            <formUtil:checkBox command="${command}" field="validationCode" showLabel="true" disabled="${!disabledForAdmins}"/>
         </div>
     </fieldset>
     <fieldset class="row">
         <div class="form-group col-md-6">
-            <formUtil:checkBox command="${command}" field="validationPhone" showLabel="true" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+            <formUtil:checkBox command="${command}" field="validationPhone" showLabel="true" disabled="${!disabledForAdmins}"/>
         </div>
 
     </fieldset>
     <fieldset class="row">
 
         <div class="form-group col-md-6">
-            <formUtil:input command="${command}" field="smsDomainName" showLabel="true" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+            <formUtil:input command="${command}" field="smsDomainName" showLabel="true" disabled="${!disabledForAdmins}"/>
         </div>
         <div class="form-group col-md-6">
-            <formUtil:selectPhonePrefix command="${command}" field="defaultPhonePrefix" showLabel="true" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+            <formUtil:selectPhonePrefix command="${command}" field="defaultPhonePrefix" showLabel="true" disabled="${!disabledForAdmins}"/>
         </div>
     </fieldset>
 </div>

--- a/grails-app/views/admin/_domainValidationForm.gsp
+++ b/grails-app/views/admin/_domainValidationForm.gsp
@@ -1,5 +1,5 @@
 <g:set var="disabledForAdmins" value="${grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_ADMIN") || grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_SUPER_ADMIN")}" />
-<r:require modules="forms"/>
+<r:require modules="forms,domainValidation"/>
 <div class="box-ppal-section">
     <h4 class="box-ppal-section-title"><g:message code="kuorum.web.admin.domain.contentPrivacy.label"/></h4>
     <fieldset class="row">

--- a/grails-app/views/campaigns/edit/_settingsStep.gsp
+++ b/grails-app/views/campaigns/edit/_settingsStep.gsp
@@ -1,6 +1,7 @@
 <%@ page import="org.kuorum.rest.model.notification.campaign.CampaignStatusRSDTO" %>
 <r:require modules="datepicker, postForm, debateForm" />
-
+<g:set var="disabledForAdmins" value="${grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_ADMIN")  || grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_SUPER_ADMIN")}" />
+<span>${!disabledForAdmins}</span>
 <div class="box-steps container-fluid campaign-steps">
     <g:render template="/campaigns/steps/campaignSteps" model="[mappings: mappings, attachEvent:attachEvent]"/>
 </div>
@@ -69,7 +70,7 @@
                         <g:message code="kuorum.web.commands.payment.CampaignSettingsCommand.voteType.label.left"/>:
                     </label>
                     <div class="col-sm-4 col-md-4">
-                        <formUtil:selectEnum command="${command}" field="voteType" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}" showLabel="false"/>
+                        <formUtil:selectEnum command="${command}" field="voteType" disabled="${!disabledForAdmins}" showLabel="false"/>
                     </div>
                     <label for="campaignVisibility" class="col-sm-2 col-md-1 control-label">
                         <span class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="${g.message(code:'kuorum.web.commands.payment.CampaignSettingsCommand.campaignVisibility.label.info')}"></span>
@@ -97,7 +98,7 @@
                             <g:message code="kuorum.web.commands.payment.CampaignSettingsCommand.signVotes.label.left"/>:
                         </label>
                         <div class="col-sm-4">
-                            <formUtil:checkBox command="${command}" field="signVotes" disabled="${!grails.plugin.springsecurity.SpringSecurityUtils.ifAllGranted("ROLE_SUPER_ADMIN")}"/>
+                            <formUtil:checkBox command="${command}" field="signVotes" disabled="${!disabledForAdmins}"/>
                         </div>
                     </fieldset>
                 </g:if>

--- a/grails-app/views/campaigns/edit/_settingsStep.gsp
+++ b/grails-app/views/campaigns/edit/_settingsStep.gsp
@@ -1,7 +1,7 @@
 <%@ page import="org.kuorum.rest.model.notification.campaign.CampaignStatusRSDTO" %>
 <r:require modules="datepicker, postForm, debateForm" />
 <g:set var="disabledForAdmins" value="${grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_ADMIN")  || grails.plugin.springsecurity.SpringSecurityUtils.ifAnyGranted("ROLE_SUPER_ADMIN")}" />
-<span>${!disabledForAdmins}</span>
+
 <div class="box-steps container-fluid campaign-steps">
     <g:render template="/campaigns/steps/campaignSteps" model="[mappings: mappings, attachEvent:attachEvent]"/>
 </div>

--- a/src/groovy/kuorum/web/commands/payment/CampaignSettingsCommand.groovy
+++ b/src/groovy/kuorum/web/commands/payment/CampaignSettingsCommand.groovy
@@ -33,7 +33,7 @@ class CampaignSettingsCommand {
     CampaignValidationTypeRDTO validationType = CampaignValidationTypeRDTO.NONE;
     CampaignVisibilityRSDTO campaignVisibility = CampaignVisibilityRSDTO.VISIBLE;
     SurveyVoteTypeDTO voteType = SurveyVoteTypeDTO.ANONYMOUS;
-    Boolean signVotes;
+    Boolean signVotes = false;
     Boolean groupValidation = false;
     Boolean newsletterCommunication = false;
 

--- a/web-app/js/domainValidation.js
+++ b/web-app/js/domainValidation.js
@@ -1,0 +1,29 @@
+let smsName = $("#smsDomainName").val();
+let phonePrefix = $("#defaultPhonePrefix").val();
+
+$(document).ready(function() {
+    enableSmsFields();
+
+    if ($("#validationPhone").click(function () {
+        enableSmsFields();
+    }));
+});
+
+function enableSmsFields() {
+
+    toogleInputDisabled(!$("#validationPhone").prop('checked'));
+}
+
+function toogleInputDisabled(disableFields) {
+    $("#smsDomainName").prop('disabled', disableFields);
+    $("#defaultPhonePrefix").prop('disabled', disableFields);
+    if(disableFields) {
+        smsName = $("#smsDomainName").val();
+        phonePrefix = $("#defaultPhonePrefix").val();
+        $("#smsDomainName").val('');
+        $("#defaultPhonePrefix").val('');
+    } else {
+        $("#smsDomainName").val(smsName);
+        $("#defaultPhonePrefix").val(phonePrefix);
+    }
+}

--- a/web-app/js/domainValidation.js
+++ b/web-app/js/domainValidation.js
@@ -1,29 +1,37 @@
-let smsName = $("#smsDomainName").val();
-let phonePrefix = $("#defaultPhonePrefix").val();
-
-$(document).ready(function() {
-    enableSmsFields();
+$(document).ready(function () {
+    domainValidationFunctions.checkSmsFieldsVisibility();
 
     if ($("#validationPhone").click(function () {
-        enableSmsFields();
-    }));
+        domainValidationFunctions.checkSmsFieldsVisibility();
+    })) ;
 });
 
-function enableSmsFields() {
-
-    toogleInputDisabled(!$("#validationPhone").prop('checked'));
-}
-
-function toogleInputDisabled(disableFields) {
-    $("#smsDomainName").prop('disabled', disableFields);
-    $("#defaultPhonePrefix").prop('disabled', disableFields);
-    if(disableFields) {
-        smsName = $("#smsDomainName").val();
-        phonePrefix = $("#defaultPhonePrefix").val();
+var domainValidationFunctions = {
+    smsName:$("#smsDomainName").val(),
+    phonePrefix:$("#defaultPhonePrefix").val(),
+    toogleInputVisibility: function (disableFields = false) {
+        $("#smsDomainName").prop('disabled', disableFields);
+        $("#defaultPhonePrefix").prop('disabled', disableFields);
+        if (disableFields) {
+            domainValidationFunctions.getVariableValueFromInput();
+            domainValidationFunctions.setInputValuesToBlank();
+        } else {
+            domainValidationFunctions.setVariablesValuesOnInput();
+        }
+    },
+    getVariableValueFromInput: function () {
+        domainValidationFunctions.smsName = $("#smsDomainName").val();
+        domainValidationFunctions.phonePrefix = $("#defaultPhonePrefix").val();
+    },
+    checkSmsFieldsVisibility: function () {
+        domainValidationFunctions.toogleInputVisibility(!$("#validationPhone").prop('checked'));
+    },
+    setInputValuesToBlank: function (){
         $("#smsDomainName").val('');
         $("#defaultPhonePrefix").val('');
-    } else {
-        $("#smsDomainName").val(smsName);
-        $("#defaultPhonePrefix").val(phonePrefix);
+    },
+    setVariablesValuesOnInput() {
+        $("#smsDomainName").val(domainValidationFunctions.smsName);
+        $("#defaultPhonePrefix").val(domainValidationFunctions.phonePrefix);
     }
 }


### PR DESCRIPTION
Front side part:

There are 2 different tasks involved in this one.
First of all we have opened the signVotes and voteType fields to every Admin so they are gonna be able to check and change those fields. In addition, the validation type can be change in the administration panel so admins can also change them now.

On the other hand, copy campaigns button can now copy those fields. 