### PR TITLE
KPV-2293 If only one campaign is active, the participate button will …

### DIFF
--- a/grails-app/conf/kuorum/RRSSConfigFilters.groovy
+++ b/grails-app/conf/kuorum/RRSSConfigFilters.groovy
@@ -31,7 +31,7 @@ class RRSSConfigFilters {
                     model.put("_domainName", CustomDomainResolver.domainRSDTO?.name ?: "")
                     model.put("_domainResourcesPath", CustomDomainResolver.domainRSDTO?.basicRootUrlStaticResources ?: "")
                     model.put("_isActiveTour", (CustomDomainResolver.domainRSDTO.getDomainTypeRSDTO() != DomainTypeRSDTO.SURVEY)
-                            || SpringSecurityUtils.ifAllGranted("ROLE_ADMIN")  ?: false)
+                            || SpringSecurityUtils.ifAllGranted("ROLE_ADMIN") ?: false)
                     model.put("_isSurveyPlatform", domainService.isSurveyPlatform())
                     model.put("_isPrivatePlatform", CustomDomainResolver.domainRSDTO.getDomainPrivacy() != DomainPrivacyRDTO.PUBLIC)
                     model.put("_showSocialButtons", !model.get("_isPrivatePlatform"))
@@ -69,12 +69,12 @@ class RRSSConfigFilters {
         Map globalAuthorities = CustomDomainResolver.domainRSDTO?.globalAuthorities
         if (globalAuthorities) {
             List<UserRoleRSDTO> adminActiveRoles = globalAuthorities.get(UserRoleRSDTO.ROLE_ADMIN)
-            List<SolrType> searchableCampaigns = adminActiveRoles
+            List<SolrType> activeDomainCampaign = adminActiveRoles
                     .collect { it.toString() }
                     .findAll { it.startsWith("ROLE_CAMPAIGN") }
                     .collect { it.replace("ROLE_CAMPAIGN_", "") }
                     .collect { SolrType.valueOf(it) }
-            return (searchableCampaigns - [SolrType.DISTRICT_PROPOSAL, SolrType.NEWSLETTER]).sort { a, b -> a.ordinal() <=> b.ordinal() }
+            return activeDomainCampaign.sort { a, b -> a.ordinal() <=> b.ordinal() }
         } else {
             return []
         }

--- a/grails-app/views/layouts/_noLoggedHead.gsp
+++ b/grails-app/views/layouts/_noLoggedHead.gsp
@@ -10,7 +10,6 @@
 
 
     <nav:onlyPublicDomain>
-        <g:set var="tomorrow" value="${new Date() + 1}" />
         <g:set var="activeCampaignsHeader" value="${_domainActiveCampaigns.findAll{it.header}}" />
         <g:if test="${activeCampaignsHeader.size() == 1}">
             <g:set var="activeCampaign" value="${activeCampaignsHeader.get(0)}"/>

--- a/grails-app/views/layouts/_noLoggedHead.gsp
+++ b/grails-app/views/layouts/_noLoggedHead.gsp
@@ -10,11 +10,13 @@
 
 
     <nav:onlyPublicDomain>
-       <g:if test="${_domainActiveCampaigns.size() == 1}">
-           <g:set var="activeCampaign" value="${_domainActiveCampaigns.get(0)}"/>
+        <g:set var="tomorrow" value="${new Date() + 1}" />
+        <g:set var="activeCampaignsHeader" value="${_domainActiveCampaigns.findAll{it.header}}" />
+        <g:if test="${activeCampaignsHeader.size() == 1}">
+            <g:set var="activeCampaign" value="${activeCampaignsHeader.get(0)}"/>
             <li>
                 <g:link mapping="searcherSearch${activeCampaign}"
-                        class="navbar-link ${nav.activeMenuCss(mappingName: 'searcherSearch' + activeCampaign)}">
+                        class="navbar-link ${nav.activeMenuCss(mappingName: 'searcherSearch' + activeCampaignsHeader)}">
                     <span><g:message code="head.noLogged.sectors"/></span>
                 </g:link>
             </li>
@@ -28,7 +30,8 @@
                 </a>
                 <ul id="navigation-options" class="dropdown-menu dropdown-menu-right"
                     aria-labelledby="open-user-options" role="menu">
-                    <g:each in="${_domainActiveCampaigns}" var="activeSolrType">
+
+                    <g:each in="${activeCampaignsHeader}" var="activeSolrType">
                         <li>
                             <g:link mapping="searcherSearch${activeSolrType}"
                                     class="navbar-link ${nav.activeMenuCss(mappingName: 'searcherSearch' + activeSolrType)}">

--- a/grails-app/views/search/search.gsp
+++ b/grails-app/views/search/search.gsp
@@ -46,7 +46,8 @@
                 </g:link>
             </label>
         </li>
-        <g:each in="${_domainActiveCampaigns}" var="activeSolrType">
+        <g:set var="activeSearchableCampaigns" value="${_domainActiveCampaigns.findAll{it.searchable}}" />
+        <g:each in="${activeSearchableCampaigns}" var="activeSolrType">
             <li>
                 <label>
                     <g:link mapping="${'searcherSearch'+activeSolrType.toString()}" params="${params.findAll {k,v-> k!='solrType' && k!='offset' && v}}" class="${searchParams.solrType == activeSolrType?'search-option-active':''}">

--- a/src/groovy/kuorum/core/model/solr/SolrType.groovy
+++ b/src/groovy/kuorum/core/model/solr/SolrType.groovy
@@ -9,55 +9,70 @@ import org.kuorum.rest.model.communication.CampaignTypeRSDTO
  */
 enum SolrType {
 
-    KUORUM_USER("fa-user", null),
-    NEWSLETTER("fa-envelope", null),
-    POST("fa-newspaper", CampaignTypeRSDTO.POST),
-    DEBATE("fa-comments", CampaignTypeRSDTO.DEBATE),
-    EVENT("fa-calendar-star", null),
-    SURVEY("fa-chart-pie", CampaignTypeRSDTO.SURVEY),
-    PETITION("fa-microphone", CampaignTypeRSDTO.PETITION),
-    PARTICIPATORY_BUDGET("fa-money-bill-alt", CampaignTypeRSDTO.PARTICIPATORY_BUDGET),
-    DISTRICT_PROPOSAL("fa-rocket", CampaignTypeRSDTO.DISTRICT_PROPOSAL),
-    CONTEST("fa-trophy", CampaignTypeRSDTO.CONTEST),
-    CONTEST_APPLICATION("fa-scroll", CampaignTypeRSDTO.CONTEST_APPLICATION);
+    KUORUM_USER("fa-user", null, true, false),
+    NEWSLETTER("fa-envelope", null, false, false),
+    POST("fa-newspaper", CampaignTypeRSDTO.POST, true, true),
+    DEBATE("fa-comments", CampaignTypeRSDTO.DEBATE, true, true),
+    EVENT("fa-calendar-star", null, true, true),
+    SURVEY("fa-chart-pie", CampaignTypeRSDTO.SURVEY, true, true),
+    PETITION("fa-microphone", CampaignTypeRSDTO.PETITION, false, false),
+    PARTICIPATORY_BUDGET("fa-money-bill-alt", CampaignTypeRSDTO.PARTICIPATORY_BUDGET, false, false),
+    DISTRICT_PROPOSAL("fa-rocket", CampaignTypeRSDTO.DISTRICT_PROPOSAL, false, false),
+    CONTEST("fa-trophy", CampaignTypeRSDTO.CONTEST, true, true),
+    CONTEST_APPLICATION("fa-scroll", CampaignTypeRSDTO.CONTEST_APPLICATION, true, false);
+
 
     String faIcon
 
+    Boolean searchable
+
+    Boolean header
+
     CampaignTypeRSDTO campaignType
 
-    SolrType(String faIcon, CampaignTypeRSDTO campaignType) {
+    SolrType(String faIcon, CampaignTypeRSDTO campaignType, Boolean searchable, Boolean header) {
         this.faIcon = faIcon
         this.campaignType = campaignType
+        this.searchable = searchable
+        this.header = header
     }
 
     String getFaIcon() {
         return faIcon
     }
 
-    static final SolrType safeParse(String rawType){
+    Boolean getSearchable() {
+        return searchable
+    }
+
+    Boolean getHeader() {
+        return header
+    }
+
+    static final SolrType safeParse(String rawType) {
         SolrType solrType = null
-        try{
+        try {
             SolrType.valueOf(rawType)
-        }catch (Exception){
+        } catch (Exception) {
             solrType = null
         }
         return solrType
     }
 
-    static final SolrType getByCampaign(CampaignRSDTO campaignRSDTO){
-        if (campaignRSDTO.getEvent()){
+    static final SolrType getByCampaign(CampaignRSDTO campaignRSDTO) {
+        if (campaignRSDTO.getEvent()) {
             return EVENT
         }
         return getByCampaignType(campaignRSDTO.campaignType)
     }
 
-    static final SolrType getByCampaignType(CampaignTypeRSDTO campaignType){
+    static final SolrType getByCampaignType(CampaignTypeRSDTO campaignType) {
 //        if (campaignType..getEvent()){
 //            return EVENT
 //        }
-        if (campaignType == null){
+        if (campaignType == null) {
             return null;
         }
-        return SolrType.values().find {it.toString() == campaignType.toString()}
+        return SolrType.values().find { it.toString() == campaignType.toString() }
     }
 }


### PR DESCRIPTION
…go directly to the campaign finder for the active campaign.


- Added variables _searchable_ and _header_ at SolrType enum. 

- Tested with element size == 1, it does not show dropdown but generates link to go to the only active campaign type. 

- Refactored variables in gsp files of the search engine and header for non-logged in users. 