### PR TITLE
KPV-2454-campaing-show-warn-when-a-campaign-has-an-image-and-a-video

### DIFF
--- a/grails-app/taglib/kuorum/FormTagLib.groovy
+++ b/grails-app/taglib/kuorum/FormTagLib.groovy
@@ -620,6 +620,7 @@ class FormTagLib {
         def label = buildLabel(command,field, attrs.label)
         def placeHolder = attrs.placeHolder?:message(code: "${command.class.name}.${field}.placeHolder", default: '')
         def value = command."${field}"?:''
+        String helpBlock = attrs.helpBlock?:message(code: "${command.class.name}.${field}.helpBlock", default: '')
 
         if (showLabel){
             out << "<label for='${prefixFieldName}${field}'>${label}</label>"
@@ -631,6 +632,9 @@ class FormTagLib {
         """
         if(error){
             out << "<span class='error' id='${id}-error'>${g.fieldError(bean: command, field: field)}</span>"
+        }
+        if (helpBlock){
+            out << "<p class='help-block'>${helpBlock}</p>"
         }
     }
 


### PR DESCRIPTION
Warning will be displayed into "helpBlock" property for the "videoPost" url form tag. This commit be able that behaviour.