### PR TITLE
Increase max characters of bio field

### DIFF
--- a/src/groovy/kuorum/web/commands/profile/EditUserProfileCommand.groovy
+++ b/src/groovy/kuorum/web/commands/profile/EditUserProfileCommand.groovy
@@ -32,6 +32,7 @@ class EditUserProfileCommand{
     static constraints = {
         gender nullable: true
         birthday nullable:true
-        bio nullable: true, maxSize: 1000
+        /*bio1.length+bio2.length=1300 + title*/
+        bio nullable: true, maxSize: 1500
     }
 }

--- a/src/groovy/kuorum/web/commands/profile/EditUserProfileCommand.groovy
+++ b/src/groovy/kuorum/web/commands/profile/EditUserProfileCommand.groovy
@@ -32,7 +32,6 @@ class EditUserProfileCommand{
     static constraints = {
         gender nullable: true
         birthday nullable:true
-        /*bio1.length+bio2.length=1300 + title*/
         bio nullable: true, maxSize: 1500
     }
 }


### PR DESCRIPTION
The sum of the length of the two fields is 1300, but you have to add the characters of the title of both "fields", so I have set it to 1500.
Tested in local environment, they are saved correctly.