### PR TITLE
Deactivate_follow_option_in_user-profile

### DIFF
--- a/grails-app/views/kuorumUser/_popoverUser.gsp
+++ b/grails-app/views/kuorumUser/_popoverUser.gsp
@@ -1,4 +1,5 @@
 %{--<!-- POPOVER PARA IMÁGENES USUARIOS -->--}%
+<g:if test="${_isSocialNetwork}">
 <div class="popover">
     %{--<button type="button" class="close" aria-hidden="true"  data-dismiss="popover"><span class="fal fa-times-circle fa"></span><span class="sr-only"><g:message code="kuorumUser.popover.close"/></span></button>--}%
     %{--<a href="#" class="hidden" rel="nofollow"><g:message code="kuorumUser.popover.showUser"/> </a>--}%
@@ -24,3 +25,4 @@
         </div>
     </div>
 </div>
+</g:if>

--- a/grails-app/views/kuorumUser/show.gsp
+++ b/grails-app/views/kuorumUser/show.gsp
@@ -42,13 +42,14 @@
                                                                   itemtype="http://schema.org/Organization">${userUtil.roleName(user: politician)}</span>
                     </p>
                 </div>
-
+<g:if test="${_isSocialNetwork}">
                 <div class="col-sm-5 profile-actions">
                     <div class="follow-btn-group">
                         <userUtil:followButton user="${politician}" cssExtra="inverted"/>
                         <userUtil:contactButton user="${politician}" cssExtra="inverted"/>
                     </div>
                 </div>
+</g:if>
             </div>
 
             <div class="extra-padding text-left following">

--- a/grails-app/views/kuorumUser/show.gsp
+++ b/grails-app/views/kuorumUser/show.gsp
@@ -42,14 +42,14 @@
                                                                   itemtype="http://schema.org/Organization">${userUtil.roleName(user: politician)}</span>
                     </p>
                 </div>
-<g:if test="${_isSocialNetwork}">
+                <g:if test="${_isSocialNetwork}">
                 <div class="col-sm-5 profile-actions">
                     <div class="follow-btn-group">
                         <userUtil:followButton user="${politician}" cssExtra="inverted"/>
                         <userUtil:contactButton user="${politician}" cssExtra="inverted"/>
                     </div>
                 </div>
-</g:if>
+                </g:if>
             </div>
 
             <div class="extra-padding text-left following">


### PR DESCRIPTION
Using isSocialNetwork domain flag, follow and contact buttons on user profiles are hidden.

Additionally, the popover to follow user is also hidden.