### PR TITLE
KPV-3344 Unable to publish contest application without body, image and name

### DIFF
--- a/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
+++ b/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
@@ -8,6 +8,7 @@ import kuorum.web.commands.payment.CampaignContentCommand
 import kuorum.web.commands.payment.CampaignSettingsCommand
 import kuorum.web.commands.payment.contest.ContestApplicationAuthorizationsCommand
 import kuorum.web.commands.payment.contest.ContestApplicationScopeCommand
+import kuorum.web.commands.payment.contest.NewContestApplicationCommand
 import org.kuorum.rest.model.communication.CampaignRDTO
 import org.kuorum.rest.model.communication.contest.ContestApplicationRDTO
 import org.kuorum.rest.model.communication.contest.ContestApplicationRSDTO
@@ -107,15 +108,16 @@ class ContestApplicationController extends CampaignController {
     }
 
     @Secured(['ROLE_CAMPAIGN_CONTEST_APPLICATION'])
-    def saveContent(CampaignContentCommand command) {
+    def saveContent(NewContestApplicationCommand command) {
         Long campaignId = params.campaignId ? Long.parseLong(params.campaignId) : null
-        if (command.hasErrors() || command.headerPictureId == null) {
-            if (command.hasErrors()) {
-                if (command.errors.getFieldError().arguments.first() == "publishOn") {
-                    flash.error = message(code: "debate.scheduleError")
-                }
-            } else {
-                flash.error = message(code: "contestApplication.imageUrl.nullable") // Additional error message for contestApplication with no uploaded image
+
+        if (command.hasErrors()) {
+            if (command.errors.getFieldError().field.toString() == "headerPictureId") {
+                flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.headerPictureId.nullable')
+            }else if (command.errors.getFieldError().field.toString() == "body"){
+                flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.body.nullable')
+            }else{
+                flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.name.nullable')
             }
             render view: 'editContentStep', model: campaignModelContent(campaignId, null, command, contestApplicationService)
             return

--- a/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
+++ b/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
@@ -13,7 +13,6 @@ import org.kuorum.rest.model.communication.CampaignRDTO
 import org.kuorum.rest.model.communication.contest.ContestApplicationRDTO
 import org.kuorum.rest.model.communication.contest.ContestApplicationRSDTO
 import org.kuorum.rest.model.communication.contest.ContestRSDTO
-import org.kuorum.rest.model.communication.contest.PageContestApplicationRSDTO
 import org.kuorum.rest.model.communication.survey.CampaignVisibilityRSDTO
 import org.kuorum.rest.model.kuorumUser.BasicDataKuorumUserRSDTO
 import org.kuorum.rest.model.notification.campaign.CampaignStatusRSDTO

--- a/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
+++ b/grails-app/controllers/kuorum/contest/ContestApplicationController.groovy
@@ -112,17 +112,13 @@ class ContestApplicationController extends CampaignController {
         Long campaignId = params.campaignId ? Long.parseLong(params.campaignId) : null
 
         if (command.hasErrors()) {
-            if (command.errors.getFieldError().field.toString() == "headerPictureId") {
+            boolean isHeaderPictureIdError = errors.any { error -> command.errors.getFieldError().field == "headerPictureId" }
+            if (isHeaderPictureIdError) {
                 flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.headerPictureId.nullable')
-            }else if (command.errors.getFieldError().field.toString() == "body"){
-                flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.body.nullable')
-            }else{
-                flash.error = message(code: 'kuorum.web.commands.payment.contest.NewContestApplicationCommand.name.nullable')
             }
             render view: 'editContentStep', model: campaignModelContent(campaignId, null, command, contestApplicationService)
             return
         }
-
         Map<String, Object> result = saveAndSendCampaignContent(command, campaignId, contestApplicationService)
         redirect mapping: result.nextStep.mapping, params: result.nextStep.params
     }

--- a/grails-app/controllers/kuorum/politician/CampaignController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignController.groovy
@@ -384,18 +384,7 @@ class CampaignController {
             // Save video
             String youtubeUrl = command.videoPost.encodeAsYoutubeName();
             campaignRDTO.setVideoUrl(youtubeUrl)
-
-            // Remove image
-          /* if (command.headerPictureId) {
-                KuorumFile picture = KuorumFile.get(command.headerPictureId)
-                fileService.deleteKuorumFile(picture)
-                command.setHeaderPictureId(null)
-                campaignRDTO.setPhotoUrl(null)
-            }*/
         }
-        /*else{
-            campaignRDTO.setVideoUrl(null)
-        }*/
         campaignRDTO
     }
 

--- a/grails-app/controllers/kuorum/politician/CampaignController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignController.groovy
@@ -330,6 +330,7 @@ class CampaignController {
                 if (campaignRSDTO.videoUrl) {
                     command.videoPost = campaignRSDTO.videoUrl
                     command.fileType = FileType.YOUTUBE.toString()
+                    command.headerPictureId = campaignRSDTO.photoUrl
                 }
 
                 if (campaignRSDTO.datePublished) {
@@ -378,20 +379,23 @@ class CampaignController {
             campaignRDTO.setPhotoUrl(picture.getUrl())
 
             // Remove video
-            campaignRDTO.setVideoUrl(null)
-        } else if (command.fileType == FileType.YOUTUBE.toString() && command.videoPost) {
+        }
+        if (command.fileType == FileType.YOUTUBE.toString() && command.videoPost) {
             // Save video
             String youtubeUrl = command.videoPost.encodeAsYoutubeName();
             campaignRDTO.setVideoUrl(youtubeUrl)
 
             // Remove image
-            if (command.headerPictureId) {
+          /* if (command.headerPictureId) {
                 KuorumFile picture = KuorumFile.get(command.headerPictureId)
                 fileService.deleteKuorumFile(picture)
                 command.setHeaderPictureId(null)
                 campaignRDTO.setPhotoUrl(null)
-            }
+            }*/
         }
+        /*else{
+            campaignRDTO.setVideoUrl(null)
+        }*/
         campaignRDTO
     }
 

--- a/grails-app/taglib/kuorum/ImagesTagLib.groovy
+++ b/grails-app/taglib/kuorum/ImagesTagLib.groovy
@@ -82,26 +82,29 @@ class ImagesTagLib {
 
         String uploadDate = "";
         String description = "";
+        String predefinedImage = "";
         if (attrs.campaign && attrs.campaign instanceof CampaignRSDTO){
             CampaignRSDTO campaignRSDTO = attrs.campaign
             uploadDate = campaignRSDTO.datePublished?.format( "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" )?:"";
             description = campaignRSDTO.title
+            predefinedImage = campaignRSDTO.photoUrl
         }
         if (attrs.campaign && attrs.campaign instanceof SearchKuorumElementRSDTO){
             SearchKuorumElementRSDTO campaignRSDTO = attrs.campaign
             uploadDate = campaignRSDTO.dateCreated?.format( "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" )?:"";
             description = campaignRSDTO.name
+            predefinedImage = campaignRSDTO.urlImage
         }
         String imageYoutubeNotFound = g.resource(dir:"/images", file: "youtube-broken-link.png", absolute: true)
 out << """
     <div class="video click-handler-no-processed" itemscope itemtype="http://schema.org/VideoObject">
         <meta itemprop="name" content="YouTube" />
-        <meta itemprop="thumbnailUrl" content="${imageYoutubeSrc(youtube:attrs.youtube)}" />
+        <meta itemprop="thumbnailUrl" content="${imageYoutubeSrc(youtube:attrs.youtube, predefinedImage: predefinedImage)}" />
         <meta itemprop="uploadDate" content="${uploadDate}" />
         <meta itemprop="description" content="${description}" />
         <a href="#" class="front">
             <span class="fas fa-play-circle fa-4x"></span>
-            <img itemprop='image' src="${imageYoutubeSrc(youtube:attrs.youtube)}" data-youtubeId="${youtubeFileName}" data-urlYoutubeNotFound="${imageYoutubeNotFound}">
+            <img itemprop='image' src="${imageYoutubeSrc(youtube:attrs.youtube, predefinedImage: predefinedImage)}" data-youtubeId="${youtubeFileName}" data-urlYoutubeNotFound="${imageYoutubeNotFound}">
         </a>
         <div id="youtube-${youtubeFileName}" class="youtube" data-youtubeId="${youtubeFileName}"></div>
     </div>
@@ -109,19 +112,25 @@ out << """
     }
 
     def imageYoutubeSrc = {attrs ->
+
         Boolean maxResolution = attrs.maxResolution?Boolean.parseBoolean(attrs.maxResolution):false
-        String youtubeFileName = ""
-        if (attrs.youtube instanceof String){
-            youtubeFileName = attrs.youtube.decodeYoutubeName()
-        }else{
-            KuorumFile youtube = attrs.youtube
-            youtubeFileName = youtube.fileName
+        String predefinedImage = attrs.predefinedImage?: ""
+        if(predefinedImage){
+            out << predefinedImage
+        } else { // Recovering default imagne from Youtube
+            String youtubeFileName = ""
+            if (attrs.youtube instanceof String) {
+                youtubeFileName = attrs.youtube.decodeYoutubeName()
+            } else {
+                KuorumFile youtube = attrs.youtube
+                youtubeFileName = youtube.fileName
+            }
+            String screenShot = "mqdefault.jpg" // Si es de alta resolucion se podría poner maxresdefault.jpg
+            if (maxResolution) {
+                screenShot = "maxresdefault.jpg"
+            }
+            out << "https://img.youtube.com/vi/${youtubeFileName}/${screenShot}"
         }
-        String screenShot = "mqdefault.jpg" // Si es de alta resolucion se podría poner maxresdefault.jpg
-        if (maxResolution){
-            screenShot = "maxresdefault.jpg"
-        }
-        out << "https://img.youtube.com/vi/${youtubeFileName}/${screenShot}"
     }
 
     def loggedUserImgSrc={attrs ->

--- a/grails-app/views/campaigns/cards/_campaignMultimediaCard.gsp
+++ b/grails-app/views/campaigns/cards/_campaignMultimediaCard.gsp
@@ -1,9 +1,9 @@
 <div class="card-header-photo">
-    <g:if test="${campaign.photoUrl}">
-        <img src="${campaign.photoUrl}" alt="${campaign.title}">
-    </g:if>
-    <g:elseif test="${campaign.videoUrl}">
+    <g:if test="${campaign.videoUrl}">
         <image:showYoutube youtube="${campaign.videoUrl}" campaign="${campaign}"/>
+    </g:if>
+    <g:elseif test="${campaign.photoUrl}">
+        <img itemprop="image" src="${campaign.photoUrl}" alt="${campaign.title}">
     </g:elseif>
     <g:else>
         <div class="imagen-shadowed-main-color-domain">

--- a/grails-app/views/campaigns/showModules/_campaignDataMultimedia.gsp
+++ b/grails-app/views/campaigns/showModules/_campaignDataMultimedia.gsp
@@ -1,9 +1,9 @@
 <div class="multimedia-campaign">
-    <g:if test="${campaign.photoUrl}">
-        <img itemprop="image" src="${campaign.photoUrl}" alt="${campaign.title}">
-    </g:if>
-    <g:elseif test="${campaign.videoUrl}">
+    <g:if test="${campaign.videoUrl}">
         <image:showYoutube youtube="${campaign.videoUrl}" campaign="${campaign}"/>
+    </g:if>
+    <g:elseif test="${campaign.photoUrl}">
+        <img itemprop="image" src="${campaign.photoUrl}" alt="${campaign.title}">
     </g:elseif>
     <g:else>
         <div class="imagen-shadowed-main-color-domain">

--- a/src/groovy/kuorum/web/commands/payment/CampaignContentCommand.groovy
+++ b/src/groovy/kuorum/web/commands/payment/CampaignContentCommand.groovy
@@ -50,7 +50,7 @@ class CampaignContentCommand {
             }
         }
         body nullable: true, maxCharsHtml: 1000, validator: { val, obj ->
-            if (!val) {
+            if (obj.publishOn && !val) {
                 return "kuorum.web.commands.payment.massMailing.DebateCommand.body.nullable"
             }
         }

--- a/src/groovy/kuorum/web/commands/payment/contest/NewContestApplicationCommand.groovy
+++ b/src/groovy/kuorum/web/commands/payment/contest/NewContestApplicationCommand.groovy
@@ -9,12 +9,12 @@ import org.kuorum.rest.model.communication.survey.CampaignVisibilityRSDTO
 
 @Validateable
 class NewContestApplicationCommand extends CampaignContentCommand {
-    String name
+
     Long contestId
 
     static constraints = {
         contestId nullable: false
-        name nullable: false
+        title nullable: false
         body nullable: false
         headerPictureId nullable: false
     }

--- a/src/groovy/kuorum/web/commands/payment/contest/NewContestApplicationCommand.groovy
+++ b/src/groovy/kuorum/web/commands/payment/contest/NewContestApplicationCommand.groovy
@@ -11,14 +11,12 @@ import org.kuorum.rest.model.communication.survey.CampaignVisibilityRSDTO
 class NewContestApplicationCommand extends CampaignContentCommand {
     String name
     Long contestId
-    String cause
-    ContestApplicationActivityTypeDTO activityType
-    ContestApplicationFocusTypeDTO focusType
 
     static constraints = {
-        importFrom CampaignContentCommand
         contestId nullable: false
         name nullable: false
+        body nullable: false
+        headerPictureId nullable: false
     }
 
 }


### PR DESCRIPTION
Unable to publish contest applications with empty body or image
Added conditions to show each error separately
Prevent null name because may cause data inconsistency (is campaign title, mandatory in several steps)