### PR TITLE
KPV-3345 fix image and video bug V1

### DIFF
--- a/grails-app/controllers/kuorum/politician/CampaignController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignController.groovy
@@ -368,9 +368,8 @@ class CampaignController {
         CampaignRDTO campaignRDTO = createRDTO(user, campaignId, campaignService)
         campaignRDTO.title = command.title
         campaignRDTO.body = command.body
-
         // Multimedia URL
-        if (command.fileType == FileType.IMAGE.toString() && command.headerPictureId) {
+        if (command.headerPictureId) {
             // Save image
             KuorumFile picture = KuorumFile.get(command.headerPictureId)
             picture.setCampaignId(campaignId)
@@ -378,7 +377,7 @@ class CampaignController {
             fileService.deleteTemporalFiles(user)
             campaignRDTO.setPhotoUrl(picture.getUrl())
         }
-        if (command.fileType == FileType.YOUTUBE.toString() && command.videoPost) {
+        if (command.videoPost) {
             // Save video
             String youtubeUrl = command.videoPost.encodeAsYoutubeName();
             campaignRDTO.setVideoUrl(youtubeUrl)


### PR DESCRIPTION
Fix image and video not saving properly. V1
Resolved the image and video bug. 
What was happening is that command.fileType was overwriting its value if YOUTUBE and IMAGE are present witch implies not handling previous fileType value.
This type check has been removed, while maintaining the null/empty check for the content of command.headerPictureId and command.videoPost.
