### PR TITLE
KPV-3330 Google captcha security fix

### DIFF
--- a/grails-app/services/kuorum/captcha/CaptchaService.groovy
+++ b/grails-app/services/kuorum/captcha/CaptchaService.groovy
@@ -12,25 +12,27 @@ class CaptchaService {
     String RECAPTCHA_SECRET
 
     def verifyCaptcha(String responseCaptcha) {
-
-            String secretKey = RECAPTCHA_SECRET
-            String path = "/recaptcha/api/siteverify"
-            def query = [secret: secretKey, response: responseCaptcha]
-            RESTClient mailKuorumServices = new RESTClient("https://www.google.com")
-            def response = mailKuorumServices.get(path: path,
-                    headers: ["User-Agent": "Kuorum Web"],
-                    query: query,
-                    requestContentType: groovyx.net.http.ContentType.JSON)
-
-            log.info("Checking CAPTCHA :: Google response - ${response.data.hostname} || domain : ${CustomDomainResolver.domain}")
-
-            def isCaptchaVerified = false
-            if (response.data.hostname != CustomDomainResolver.domain) {
-                log.info("invalid captcha domain")
-            } else {
-                isCaptchaVerified = response.data.success
-            }
+        def isCaptchaVerified = false
+        if (!responseCaptcha) {
             return isCaptchaVerified
+        }
+        String secretKey = RECAPTCHA_SECRET
+        String path = "/recaptcha/api/siteverify"
+        def query = [secret: secretKey, response: responseCaptcha]
+        RESTClient mailKuorumServices = new RESTClient("https://www.google.com")
+        def response = mailKuorumServices.get(path: path,
+                headers: ["User-Agent": "Kuorum Web"],
+                query: query,
+                requestContentType: groovyx.net.http.ContentType.JSON)
+
+        log.info("Checking CAPTCHA :: Google response - ${response.data.hostname} || domain : ${CustomDomainResolver.domain}")
+
+        if (response.data.hostname != CustomDomainResolver.domain) {
+            log.info("invalid captcha domain")
+        } else if (response.data.success) {
+            isCaptchaVerified = true
+        }
+        return isCaptchaVerified
 
     }
 }


### PR DESCRIPTION
Edit verify captcha method in CaptchaService.
Force failing verification if captcha response param is null or empty.
Captcha verification get its boolean value based on response data.

Used URL →→ /ajax/validation/domain-valid-phone-sendSms?phoneNumberPrefix=0034&
phoneNumber=660010443&
phoneNumber2=660010443&
phoneNumberPrefix2=0034&
g-recaptcha-response=XXXX


![image](https://github.com/Kuorum/kuorum/assets/71281111/1fa092cd-738c-4821-b99d-7a1080852b7e)

![image](https://github.com/Kuorum/kuorum/assets/71281111/3ec8b328-e54a-40d0-8593-ee01637ab6de)








