### PR TITLE
KPV-3345 Fix custom image in youtube preview

### DIFF
--- a/web-app/js/youtube-helper.js
+++ b/web-app/js/youtube-helper.js
@@ -76,7 +76,10 @@ function YoutubeHelper(){
         }
 
         validYoutube(youtubeId, function(data){
-            maxResImage(data, img);
+            // Campaign has custom image
+            var isCampaignThumbnailUrl = !$('meta[itemprop="thumbnailUrl"]').attr("content").includes("youtube");
+            console.log("Custom image: "+isCampaignThumbnailUrl)
+            isCampaignThumbnailUrl? '': maxResImage(data, img);
         }, function(){
            // setErrorYoutubeImage();
             console.log("Error loading youtube data");


### PR DESCRIPTION
Modified logic to prevent YouTube video image preview from being used if campaign has a custom image