### PR TITLE
KPV-3801 Make fields phone, phone prefix and email non editable. Update MIN_FILES_PER_DOC_IN_CONTEST constant

### DIFF
--- a/grails-app/views/profile/_accountDetailsForm.gsp
+++ b/grails-app/views/profile/_accountDetailsForm.gsp
@@ -9,7 +9,7 @@
 </fieldset>
 <fieldset aria-live="polite" class="row">
     <div class="form-group col-md-6">
-        <formUtil:input command="${command}" field="email" required="true" showLabel="true"/>
+        <formUtil:input command="${command}" field="email" required="true" showLabel="true" disabled="true"/>
     </div>
     <div class="form-group col-md-6">
         <formUtil:input command="${command}" field="alias" showLabel="true" showCharCounter="false" helpBlock="https://${kuorum.core.customDomain.CustomDomainResolver.domainRSDTO.domain}/${command.alias?:'alias'}"/>
@@ -29,9 +29,9 @@
         <formUtil:regionInput command="${command}" field="homeRegion" showLabel="true"/>
     </div>
     <div class="form-group col-md-2">
-        <formUtil:selectPhonePrefix command="${command}" field="phonePrefix" showLabel="true"/>
+        <formUtil:selectPhonePrefix command="${command}" field="phonePrefix" showLabel="true" disabled="true"/>
     </div>
     <div class="form-group col-md-4">
-        <formUtil:input command="${command}" field="phone" showLabel="true" type="number"/>
+        <formUtil:input command="${command}" field="phone" showLabel="true" type="number" disabled="true"/>
     </div>
 </fieldset>

--- a/src/groovy/kuorum/web/constants/WebConstants.groovy
+++ b/src/groovy/kuorum/web/constants/WebConstants.groovy
@@ -24,7 +24,7 @@ class WebConstants {
     public static final String WEB_PARAM_LANG = "lang"
 
     public static final String FAKE_LANDING_ALIAS_USER = "admin"
-    public static final Integer MIN_FILES_PER_DOC_IN_CONTEST = 3;
+    public static final Integer MIN_FILES_PER_DOC_IN_CONTEST = 2;
 
     public static final String FAKE_USER_EMAIL_DOMAIN = "@fake.com"
     public static final String NO_REAL_USER_EMAIL_DOMAIN = "@norealuser.com"


### PR DESCRIPTION
Disable phone prefix, phone and email fields in account-details section
Set MIN_FILES_PER_DOC_IN_CONTEST constant to 2