### PR TITLE
KPV-6564 Add aria-live assertive to force alert to be read

### DIFF
--- a/web-app/js/custom.js
+++ b/web-app/js/custom.js
@@ -415,7 +415,7 @@ var display = {
                 speed: 500 // opening & closing animation speed
             },
             timeout: 0,
-            template: '<div class="noty_message" role="alert"><span class="noty_text"></span><span class="noty_close_fake fal fa-times-square"></span></div>',
+            template: '<div class="noty_message" role="alert" aria-live="assertive"><span class="noty_text"></span><span class="noty_close_fake fal fa-times-square"></span></div>',
             type: type,
             text: htmlText
         });


### PR DESCRIPTION
After doing some concept research, I have found a tag that seems to be just what we are looking for: aria-live=‘assertive’.

As seen in MDN:

`aria-live="assertive"` should only be used for time-sensitive/critical notifications that absolutely require the user's immediate attention. Generally, a change to an assertive live region will interrupt any announcement a screen reader is currently making. As such, it can be extremely annoying and disruptive and should only be used sparingly.

Ref: [https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions](url)