### PR TITLE
KPV-6565 Refactor h1 to h2 element in contest and search layouts 

### DIFF
--- a/grails-app/views/campaigns/cards/_campaignBodyCard.gsp
+++ b/grails-app/views/campaigns/cards/_campaignBodyCard.gsp
@@ -1,9 +1,9 @@
 <div class="card-body">
-    <h1>
+    <h2>
         <a href="${campaignLink}" class="link-wrapper-clickable">
             ${campaign.title}
         </a>
-    </h1>
+    </h2>
     %{--<g:if test="${!surveyMultimedia}">--}%
     %{--<div class="card-text"><modulesUtil:shortText text="${campaign.body}"/></div>--}%
     %{--</g:if>--}%

--- a/grails-app/views/campaigns/cards/_searchCampaignList.gsp
+++ b/grails-app/views/campaigns/cards/_searchCampaignList.gsp
@@ -19,11 +19,11 @@
             </div>
         %{--</g:if>--}%
             <div class="card-body">
-                <h1>
+                <h2>
                     <g:link mapping="campaignShow" class="link-wrapper-clickable" params="${campaign.encodeAsLinkProperties()}">
                         <searchUtil:highlightedField searchElement="${campaign}" field="name"/>
                     </g:link>
-                </h1>
+                </h2>
         </div>
         <div class="card-footer">
             <ul>

--- a/web-app/css/custom.css
+++ b/web-app/css/custom.css
@@ -3842,6 +3842,7 @@ ul.search-list > li.search-article .box-ppal .card-header-photo {height: auto;}
 ul.search-list > li.search-article .box-ppal .card-body {padding:1em;overflow: hidden;height: 325px;}
 ul.search-list > li.search-article .box-ppal .card-header-photo + .card-body {height: 125px; margin-bottom: 15px;}
 ul.search-list > li.search-article .box-ppal .card-body h1{text-align:left; margin:0; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif}
+ul.search-list > li.search-article .box-ppal .card-body h2{text-align:left; margin:0; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 25px}
 ul.search-list > li.search-article .box-ppal .card-body .card-text{margin:0;padding:1em 0 0 0;text-overflow: ellipsis;word-break: break-word;}
 ul.search-list > li.search-article .box-ppal .card-body .card-text a{color: #ec931f;}
 ul.search-list > li.search-article .box-ppal .card-body .card-text a:hover{text-decoration: underline;}


### PR DESCRIPTION
Refactored card body from H2 to H1. Minor css changes. Check screenshots:

Search layout:

LOCAL ENV: 
![image](https://github.com/user-attachments/assets/84d7cb86-44f3-4f94-9b71-8590d7c32484)

PRO ENV (just to compare):
![image](https://github.com/user-attachments/assets/fa844b07-a7a9-41af-9615-3e6cb42703ad)

Contest layout:

LOCAL ENV: 
![image](https://github.com/user-attachments/assets/9ffbbc27-10d4-413f-8349-d68e8cb8ca25)

PRO ENV (just to compare): 
![image](https://github.com/user-attachments/assets/24793d26-896e-4659-88d7-c920087022e8)
