### PR TITLE
KPV-7755 User is not logged out after casting its vote if phone number exists in contact

### DIFF
--- a/grails-app/controllers/kuorum/contest/ContestController.groovy
+++ b/grails-app/controllers/kuorum/contest/ContestController.groovy
@@ -14,6 +14,7 @@ import org.kuorum.rest.model.communication.contest.*
 import org.kuorum.rest.model.kuorumUser.BasicDataKuorumUserRSDTO
 import org.kuorum.rest.model.notification.campaign.CampaignStatusRSDTO
 import org.kuorum.rest.model.search.DirectionDTO
+import kuorum.register.RegisterService
 
 import java.lang.reflect.UndeclaredThrowableException
 
@@ -23,6 +24,8 @@ class ContestController extends CampaignController {
 
     // Grails renderer -> For CSV hack
     grails.gsp.PageRenderer groovyPageRenderer
+
+    RegisterService registerService
 
     @Secured(['ROLE_CAMPAIGN_CONTEST'])
     def create() {
@@ -408,7 +411,9 @@ class ContestController extends CampaignController {
             }
             render([success: false, message: msgError, vote: null] as JSON)
         } finally {
+            // Cinfa needs to log out user to allow several voter in same device
             cookieUUIDService.removeUserUUID();
+            registerService.logout(request, response, false)
         }
     }
 

--- a/grails-app/controllers/kuorum/politician/CampaignValidationController.groovy
+++ b/grails-app/controllers/kuorum/politician/CampaignValidationController.groovy
@@ -186,7 +186,7 @@ class CampaignValidationController {
             KuorumUserSession userSession = springSecurityService.principal
             if (userSession.email != contact.email) {
                 log.info("VALIDATION: censusOrExternalIdLogion: ${censusLogin ?: userSession.name} -> Logging out user (${userSession.email}) because it is using a censusLogin of different contact (${contact.email}")
-                registerService.logout(request, response)
+                registerService.logout(request, response, true)
             }
         }
     }

--- a/grails-app/services/kuorum/register/RegisterService.groovy
+++ b/grails-app/services/kuorum/register/RegisterService.groovy
@@ -270,7 +270,7 @@ class RegisterService {
                 params: linkParams)
     }
 
-    void logout(HttpServletRequest request, HttpServletResponse response){
+    void logout(HttpServletRequest request, HttpServletResponse response, Boolean createNewSession){
         if (springSecurityService.isLoggedIn()){
             KuorumUserSession userSession = springSecurityService.principal
             List<PersistentLoginToken> rememberMeTokens = PersistentLoginToken.findAllByUsername(userSession.username)
@@ -282,11 +282,13 @@ class RegisterService {
                 new SecurityContextLogoutHandler().logout(request, response, auth);
             }
             SecurityContextHolder.getContext().setAuthentication(null);
-            HttpSession session = request.getSession();
+            HttpSession session = request.getSession(createNewSession);
             session.invalidate();
             SecurityContextHolder.clearContext();
             //CREATING A NEW EMPTY SESSION
-            request.getSession(true)
+            if(createNewSession){
+                request.getSession(createNewSession)
+            }
         }
     }
 }


### PR DESCRIPTION
Now, if contact has phone number and votes using this same number, then related user is logged in, not asking user to enter its phone to cast its vote again. In order to allow different users to cast its vote using same device, we are going to log out any user after vote action is executed